### PR TITLE
fix render when ctx.children is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,9 @@ export default {
   },
   render(h, ctx) {
     const code =
-      ctx.props.code || (ctx.children && ctx.children.length > 0)
+      ctx.props.code || ((ctx.children && ctx.children.length > 0)
         ? ctx.children[0].text
-        : ''
+        : '')
     const inline = ctx.props.inline
     const language = ctx.props.language
     const prismLanguage = Prism.languages[language]


### PR DESCRIPTION
this was equivalent to 

```js
const code (ctx.props.code || (ctx.children && ctx.children.length > 0))
        ? ctx.children[0].text
        : ''
```