### PR TITLE
fix: bug when pass code using code prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,9 @@ export default {
   },
   render(h, ctx) {
     const code =
-      ctx.props.code || (ctx.children && ctx.children.length > 0)
+      ctx.props.code || ((ctx.children && ctx.children.length > 0)
         ? ctx.children[0].text
-        : ''
+        : '')
     const inline = ctx.props.inline
     const language = ctx.props.language
     const prismLanguage = Prism.languages[language]


### PR DESCRIPTION
you should wrap ternary operator in parentheses, to make sure it will work if I pass my snippet using `code` prop