### PR TITLE
bundle Prism in the ESM version to prevent Vite issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "homepage": "https://egoistian.com/vue-prism-component/",
   "main": "dist/vue-prism-component.common.js",
+  "module": "dist/vue-prism-component.esm.js",
   "cdn": "dist/vue-prism-component.min.js",
   "unpkg": "dist/vue-prism-component.min.js",
   "files": [
@@ -17,9 +18,10 @@
     "test": "echo skip",
     "lint": "xo",
     "prepublishOnly": "npm run build",
-    "build": "npm run build:umd && npm run build:cjs",
+    "build": "npm run build:umd && npm run build:cjs && npm run build:esm",
     "build:umd": "bili --file-name \"vue-prism-component[min].js\" --format umd --format umd-min --env.NODE_ENV production --module-name PrismComponent --external prismjs --external vue",
-    "build:cjs": "bili --file-name \"vue-prism-component.common.js\" --format cjs"
+    "build:cjs": "bili --file-name \"vue-prism-component.common.js\" --format cjs",
+    "build:esm": "bili --file-name \"vue-prism-component.esm.js\" --format esm --bundle-node-modules"
   },
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
fixes: #40

PS: we can remove `--bundle-node-modules` again once the ESM version of Prism comes out.