### PR TITLE
fix: ignored `code` prop and missing children when no slot

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,8 @@ export default defineComponent({
     }
   },
   setup(props, { slots, attrs }) {
-    const defaultSlot = (slots && slots.default && slots.default()) || []
-    const code =
-      props.code || (defaultSlot && defaultSlot.length)
-        ? defaultSlot[0].children
-        : ''
+    const defaultSlot = (slots.default && slots.default()) || []
+    const code = props.code || defaultSlot.length && defaultSlot[0].children || ''
     const inline = props.inline
     const language = props.language
     const prismLanguage = Prism.languages[language]


### PR DESCRIPTION
## Bug

When default slot is not set:
 - it causes TypeError due missing children property;
 - `code` prop is still ignored


## Reason

Original conditional clause is slightly incorrect:

```js
const code = props.code || (defaultSlot && defaultSlot.length)
        ? defaultSlot[0].children
        : ''
```
Let's take when we have code and no slot. It becomes to:
```js
const code = "some text" || ([] && 0) ? [][0].children : '';

// reduct

const code = "some text" ||  0  ? [][0].children : '';

// reduct

const code = true ? [][0].children : '';

// reduct

const code = [][0].children;

```
